### PR TITLE
chore(deps): bump openai from 4.47.1 to 4.55.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "next-themes": "0.3.0",
     "node-id3": "0.2.6",
     "open-graph-scraper": "6.5.1",
-    "openai": "4.47.1",
+    "openai": "4.55.3",
     "pangu": "4.0.7",
     "path-to-regexp": "6.2.2",
     "pinyin-pro": "3.20.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,7 +214,7 @@ importers:
         version: 0.16.10
       langchain:
         specifier: 0.1.37
-        version: 0.1.37(axios@1.7.2)(cheerio@1.0.0-rc.12)(ignore@5.3.1)(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.47.1)(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        version: 0.1.37(axios@1.7.2)(cheerio@1.0.0-rc.12)(ignore@5.3.1)(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.55.3(zod@3.23.8))(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       lottie-react:
         specifier: 2.4.0
         version: 2.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -249,8 +249,8 @@ importers:
         specifier: 6.5.1
         version: 6.5.1
       openai:
-        specifier: 4.47.1
-        version: 4.47.1
+        specifier: 4.55.3
+        version: 4.55.3(zod@3.23.8)
       pangu:
         specifier: 4.0.7
         version: 4.0.7
@@ -1151,6 +1151,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1158,6 +1159,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@ianvs/prettier-plugin-sort-imports@4.2.1':
     resolution: {integrity: sha512-NKN1LVFWUDGDGr3vt+6Ey3qPeN/163uR1pOPAlkWpgvAqgxQ6kSdUf1F0it8aHUtKRUzEGcK38Wxd07O61d7+Q==}
@@ -2407,6 +2409,7 @@ packages:
 
   '@walletconnect/sign-client@2.11.0':
     resolution: {integrity: sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==}
+    deprecated: Reliability and performance greatly improved - please see https://github.com/WalletConnect/walletconnect-monorepo/releases
 
   '@walletconnect/time@1.0.2':
     resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
@@ -3983,6 +3986,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -4223,6 +4227,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -5448,9 +5453,14 @@ packages:
     resolution: {integrity: sha512-gYlqM3II4tHgegWUGxLHrm/Pa+HWz+SeAQz+yiYYl2O7JiXTM9DmNdk3piPvOodewgXiuOc1dTr1inR+gwCcxg==}
     engines: {node: '>=18.0.0'}
 
-  openai@4.47.1:
-    resolution: {integrity: sha512-WWSxhC/69ZhYWxH/OBsLEirIjUcfpQ5+ihkXKp06hmeYXgBBIUCa9IptMzYx6NdkiOCsSGYCnTIsxaic3AjRCQ==}
+  openai@4.55.3:
+    resolution: {integrity: sha512-/IUDdK5w3aB1Kd88Ml7w5F+EkVM5aXlrY+lSpWXdIPL18CmGkC7lV9HFJ7beR0OUSFLFT0qmWvMynqtbMF06/Q==}
     hasBin: true
+    peerDependencies:
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
@@ -6131,6 +6141,7 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
   robust-predicates@3.0.2:
@@ -8286,13 +8297,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  '@langchain/community@0.0.56(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.47.1)(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@langchain/community@0.0.56(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.55.3(zod@3.23.8))(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.1.62(openai@4.47.1)
+      '@langchain/core': 0.1.62(openai@4.55.3(zod@3.23.8))
       '@langchain/openai': 0.0.28
       expr-eval: 2.0.2
       flat: 5.0.2
-      langsmith: 0.1.23(openai@4.47.1)
+      langsmith: 0.1.23(openai@4.55.3(zod@3.23.8))
       uuid: 9.0.1
       zod: 3.23.8
       zod-to-json-schema: 3.23.0(zod@3.23.8)
@@ -8305,13 +8316,13 @@ snapshots:
       - encoding
       - openai
 
-  '@langchain/core@0.1.62(openai@4.47.1)':
+  '@langchain/core@0.1.62(openai@4.55.3(zod@3.23.8))':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.11
-      langsmith: 0.1.23(openai@4.47.1)
+      langsmith: 0.1.23(openai@4.55.3(zod@3.23.8))
       ml-distance: 4.0.1
       mustache: 4.2.0
       p-queue: 6.6.2
@@ -8324,17 +8335,17 @@ snapshots:
 
   '@langchain/openai@0.0.28':
     dependencies:
-      '@langchain/core': 0.1.62(openai@4.47.1)
+      '@langchain/core': 0.1.62(openai@4.55.3(zod@3.23.8))
       js-tiktoken: 1.0.11
-      openai: 4.47.1
+      openai: 4.55.3(zod@3.23.8)
       zod: 3.23.8
       zod-to-json-schema: 3.23.0(zod@3.23.8)
     transitivePeerDependencies:
       - encoding
 
-  '@langchain/textsplitters@0.0.0(openai@4.47.1)':
+  '@langchain/textsplitters@0.0.0(openai@4.55.3(zod@3.23.8))':
     dependencies:
-      '@langchain/core': 0.1.62(openai@4.47.1)
+      '@langchain/core': 0.1.62(openai@4.55.3(zod@3.23.8))
       js-tiktoken: 1.0.11
     transitivePeerDependencies:
       - openai
@@ -12213,19 +12224,19 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  langchain@0.1.37(axios@1.7.2)(cheerio@1.0.0-rc.12)(ignore@5.3.1)(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.47.1)(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)):
+  langchain@0.1.37(axios@1.7.2)(cheerio@1.0.0-rc.12)(ignore@5.3.1)(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.55.3(zod@3.23.8))(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1
-      '@langchain/community': 0.0.56(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.47.1)(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
-      '@langchain/core': 0.1.62(openai@4.47.1)
+      '@langchain/community': 0.0.56(ioredis@5.4.1)(jsdom@24.0.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(lodash@4.17.21)(openai@4.55.3(zod@3.23.8))(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.1.62(openai@4.55.3(zod@3.23.8))
       '@langchain/openai': 0.0.28
-      '@langchain/textsplitters': 0.0.0(openai@4.47.1)
+      '@langchain/textsplitters': 0.0.0(openai@4.55.3(zod@3.23.8))
       binary-extensions: 2.3.0
       js-tiktoken: 1.0.11
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
       langchainhub: 0.0.10
-      langsmith: 0.1.23(openai@4.47.1)
+      langsmith: 0.1.23(openai@4.55.3(zod@3.23.8))
       ml-distance: 4.0.1
       openapi-types: 12.1.3
       p-retry: 4.6.2
@@ -12313,7 +12324,7 @@ snapshots:
 
   langchainhub@0.0.10: {}
 
-  langsmith@0.1.23(openai@4.47.1):
+  langsmith@0.1.23(openai@4.55.3(zod@3.23.8)):
     dependencies:
       '@types/uuid': 9.0.8
       commander: 10.0.1
@@ -12321,7 +12332,7 @@ snapshots:
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      openai: 4.47.1
+      openai: 4.55.3(zod@3.23.8)
 
   language-subtag-registry@0.3.22: {}
 
@@ -13396,7 +13407,7 @@ snapshots:
       undici: 6.6.2
       validator: 13.11.0
 
-  openai@4.47.1:
+  openai@4.55.3(zod@3.23.8):
     dependencies:
       '@types/node': 18.19.33
       '@types/node-fetch': 2.6.11
@@ -13405,7 +13416,8 @@ snapshots:
       form-data-encoder: 1.7.2
       formdata-node: 4.4.1
       node-fetch: 2.7.0
-      web-streams-polyfill: 3.3.3
+    optionalDependencies:
+      zod: 3.23.8
     transitivePeerDependencies:
       - encoding
 


### PR DESCRIPTION
### Description

In this pull request, we are updating dependencies in the `package.json` file and making changes to various packages in the `pnpm-lock.yaml` file.

Here are the key changes made in this PR:

- Update the version of the `openai` package from "4.47.1" to "4.55.3" in both `package.json` and `pnpm-lock.yaml` files.
- Add `zod@3.23.8` as a peer dependency for the `openai` package in the `pnpm-lock.yaml` file.
- Update deprecation messages for specific packages in the `pnpm-lock.yaml` file.
- Specify that certain versions of packages are deprecated and provide relevant information on improvements and changes.

These changes reflect updates to dependency versions with additional peer dependencies and updated deprecation messages to ensure better compatibility and performance.

If you have any further questions or need additional details, feel free to ask!
